### PR TITLE
Mute separation

### DIFF
--- a/components/hdw-buzzer/musical_buzzer.h
+++ b/components/hdw-buzzer/musical_buzzer.h
@@ -164,7 +164,7 @@ typedef struct
 } song_t;
 
 void buzzer_init(gpio_num_t gpio, rmt_channel_t rmt, timer_group_t group_num,
-    timer_idx_t timer_num, bool isMuted);
+    timer_idx_t timer_num, bool isBgmMuted, bool isSfxMuted);
 void buzzer_play_bgm(const song_t* song);
 void buzzer_play_sfx(const song_t* song);
 void buzzer_stop(void);

--- a/components/hdw-buzzer/musical_buzzer_rmt.c
+++ b/components/hdw-buzzer/musical_buzzer_rmt.c
@@ -35,7 +35,8 @@ typedef struct
     buzzerTrack_t sfx;
     const musicalNote_t* playNote;
     bool stopSong;
-    bool isMuted;
+    bool isBgmMuted;
+    bool isSfxMuted;
 } rmt_buzzer_t;
 
 //==============================================================================
@@ -63,14 +64,16 @@ rmt_buzzer_t rmt_buzzer;
  * @param rmt  The RMT channel to control the buzzer with
  * @param group_num The timer group number to check for note transitions with
  * @param timer_num The timer number to check for note transitions with
- * @param isMuted true to mute the buzzer, false to make it buzz
+ * @param isBgmMuted true to mute music on the buzzer, false to make it play music
+ * @param isSfxMuted true to mute sfx on the buzzer, false to make it play sfx
  */
 void buzzer_init(gpio_num_t gpio, rmt_channel_t rmt, timer_group_t group_num,
-    timer_idx_t timer_num, bool isMuted)
+    timer_idx_t timer_num, bool isBgmMuted, bool isSfxMuted)
 {
     // Don't do much if muted
-    rmt_buzzer.isMuted = isMuted;
-    if(rmt_buzzer.isMuted)
+    rmt_buzzer.isBgmMuted = isBgmMuted;
+    rmt_buzzer.isSfxMuted = isSfxMuted;
+    if(rmt_buzzer.isBgmMuted && rmt_buzzer.isSfxMuted)
     {
         return;
     }
@@ -145,7 +148,7 @@ void buzzer_init(gpio_num_t gpio, rmt_channel_t rmt, timer_group_t group_num,
 void buzzer_play_sfx(const song_t* song)
 {
     // Don't do much if muted
-    if(rmt_buzzer.isMuted)
+    if(rmt_buzzer.isSfxMuted)
     {
         return;
     }
@@ -172,7 +175,7 @@ void buzzer_play_sfx(const song_t* song)
 void buzzer_play_bgm(const song_t* song)
 {
     // Don't do much if muted
-    if(rmt_buzzer.isMuted)
+    if(rmt_buzzer.isBgmMuted)
     {
         return;
     }
@@ -264,7 +267,7 @@ static bool buzzer_track_check_next_note(buzzerTrack_t* track, bool isActive)
 static bool buzzer_check_next_note_isr(void * ptr)
 {
     // Don't do much if muted
-    if(rmt_buzzer.isMuted)
+    if(rmt_buzzer.isBgmMuted && rmt_buzzer.isSfxMuted)
     {
         return false;
     }
@@ -333,7 +336,7 @@ static void play_note(const musicalNote_t* notation)
 void buzzer_stop(void)
 {
     // Don't do much if muted
-    if(rmt_buzzer.isMuted)
+    if(rmt_buzzer.isBgmMuted && rmt_buzzer.isSfxMuted)
     {
         return;
     }

--- a/emu/src/emu_sound.c
+++ b/emu/src/emu_sound.c
@@ -57,7 +57,8 @@ emu_buzzer_t emuBzrBgm = {0};
 emu_buzzer_t emuBzrSfx = {0};
 
 // Keep track of muted state
-bool emuMuted;
+bool emuBgmMuted;
+bool emuSfxMuted;
 
 //==============================================================================
 // Function Prototypes
@@ -185,12 +186,14 @@ void EmuSoundCb(struct SoundDriver *sd UNUSED, short *in, short *out,
  * @param rmt unused
  * @param group_num unused
  * @param timer_num unused
- * @param isMuted true if sound is muted, false if it is not
+ * @param isBmgMuted true if music is muted, false if it is not
+ * @param isSfxMuted true if sfx is muted, false if it is not
  */
 void buzzer_init(gpio_num_t gpio UNUSED, rmt_channel_t rmt UNUSED,
-	timer_group_t group_num UNUSED, timer_idx_t timer_num UNUSED, bool isMuted)
+	timer_group_t group_num UNUSED, timer_idx_t timer_num UNUSED, bool isBmgMuted, bool isSfxMuted)
 {
-	emuMuted = isMuted;
+	emuBgmMuted = isBmgMuted;
+	emuSfxMuted = isSfxMuted;
 
 	buzzer_stop();
 	if (!sounddriver)
@@ -208,7 +211,7 @@ void buzzer_init(gpio_num_t gpio UNUSED, rmt_channel_t rmt UNUSED,
  */
 void buzzer_play_sfx(const song_t *song)
 {
-	if(emuMuted)
+	if(emuSfxMuted)
 	{
 		return;
 	}
@@ -229,7 +232,7 @@ void buzzer_play_sfx(const song_t *song)
  */
 void buzzer_play_bgm(const song_t *song)
 {
-	if(emuMuted)
+	if(emuBgmMuted)
 	{
 		return;
 	}
@@ -312,7 +315,7 @@ bool buzzer_track_check_next_note(emu_buzzer_t * track, bool isActive)
  */
 void buzzer_check_next_note(void)
 {
-	if(emuMuted)
+	if(emuBgmMuted && emuSfxMuted)
 	{
 		return;
 	}
@@ -339,7 +342,7 @@ void buzzer_stop_dont_clear(void)
  */
 void buzzer_stop(void)
 {
-	if(emuMuted)
+	if(emuBgmMuted && emuSfxMuted)
 	{
 		return;
 	}

--- a/main/modes/mode_main_menu.c
+++ b/main/modes/mode_main_menu.c
@@ -96,8 +96,10 @@ const char mainMenuGames[] = "Games";
 const char mainMenuTools[] = "Tools";
 const char mainMenuSettings[] = "Settings";
 const char mainMenuBack[] = "Back";
-const char mainMenuSoundOn[] = "Sound: On";
-const char mainMenuSoundOff[] = "Sound: Off";
+const char mainMenuSoundBgmOn[] = "Music: On";
+const char mainMenuSoundBgmOff[] = "Music: Off";
+const char mainMenuSoundSfxOn[] = "SFX: On";
+const char mainMenuSoundSfxOff[] = "SFX: Off";
 char mainMenuTftBrightness[] = "TFT Brightness: 1";
 char mainMenuLedBrightness[] = "LED Brightness: 1";
 char mainMenuMicGain[] = "Mic Gain: 1";
@@ -205,15 +207,25 @@ void mainMenuButtonCb(buttonEvt_t* evt)
                             incMicGain();
                         }
                     }
-                    else if(mainMenuSoundOn == mainMenu->menu->rows[mainMenu->menu->selectedRow])
+                    else if(mainMenuSoundBgmOn == mainMenu->menu->rows[mainMenu->menu->selectedRow])
                     {
-                        // Sound is on, turn it off
-                        setIsMuted(true);
+                        // Music is on, turn it off
+                        setBgmIsMuted(true);
                     }
-                    else if(mainMenuSoundOff == mainMenu->menu->rows[mainMenu->menu->selectedRow])
+                    else if(mainMenuSoundBgmOff == mainMenu->menu->rows[mainMenu->menu->selectedRow])
                     {
-                        // Sound is off, turn it on
-                        setIsMuted(false);
+                        // Music is off, turn it on
+                        setBgmIsMuted(false);
+                    }
+                    else if(mainMenuSoundSfxOn == mainMenu->menu->rows[mainMenu->menu->selectedRow])
+                    {
+                        // SFX is on, turn it off
+                        setSfxIsMuted(true);
+                    }
+                    else if(mainMenuSoundSfxOff == mainMenu->menu->rows[mainMenu->menu->selectedRow])
+                    {
+                        // SFX is off, turn it on
+                        setSfxIsMuted(false);
                     }
                     else if(mainMenuTftBrightness == mainMenu->menu->rows[mainMenu->menu->selectedRow])
                     {
@@ -269,6 +281,8 @@ void mainMenuSetUpTopMenu(bool resetPos)
     addRowToMeleeMenu(mainMenu->menu, mainMenuGames);
     addRowToMeleeMenu(mainMenu->menu, mainMenuTools);
     addRowToMeleeMenu(mainMenu->menu, mainMenuSettings);
+    addRowToMeleeMenu(mainMenu->menu, mainMenuCredits);
+
     // Set the position
     if(resetPos)
     {
@@ -299,6 +313,10 @@ void mainMenuTopLevelCb(const char* opt)
     else if(mainMenuSettings == opt)
     {
         mainMenuSetUpSettingsMenu(true);
+    }
+    else if (mainMenuCredits == opt)
+    {
+        switchToSwadgeMode(&modeCredits);
     }
 }
 
@@ -444,14 +462,23 @@ void mainMenuToolsCb(const char* opt)
 void mainMenuSetUpSettingsMenu(bool resetPos)
 {
     // Pick the menu string based on the sound option
-    const char* soundOpt;
-    if(getIsMuted())
+    const char* soundBgmOpt;
+    if(getBgmIsMuted())
     {
-        soundOpt = mainMenuSoundOff;
+        soundBgmOpt = mainMenuSoundBgmOff;
     }
     else
     {
-        soundOpt = mainMenuSoundOn;
+        soundBgmOpt = mainMenuSoundBgmOn;
+    }
+    const char* soundSfxOpt;
+    if(getSfxIsMuted())
+    {
+        soundSfxOpt = mainMenuSoundSfxOff;
+    }
+    else
+    {
+        soundSfxOpt = mainMenuSoundSfxOn;
     }
 
     // Print the tftBrightness option
@@ -465,11 +492,11 @@ void mainMenuSetUpSettingsMenu(bool resetPos)
 
     // Reset the menu
     resetMeleeMenu(mainMenu->menu, mainMenuSettings, mainMenuSettingsCb);
-    addRowToMeleeMenu(mainMenu->menu, soundOpt);
+    addRowToMeleeMenu(mainMenu->menu, soundBgmOpt);
+    addRowToMeleeMenu(mainMenu->menu, soundSfxOpt);
     addRowToMeleeMenu(mainMenu->menu, (const char*)mainMenuMicGain);
     addRowToMeleeMenu(mainMenu->menu, (const char*)mainMenuTftBrightness);
     addRowToMeleeMenu(mainMenu->menu, (const char*)mainMenuLedBrightness);
-    addRowToMeleeMenu(mainMenu->menu, mainMenuCredits);
     addRowToMeleeMenu(mainMenu->menu, mainMenuBack);
     // Set the position
     if(resetPos)
@@ -490,15 +517,25 @@ void mainMenuSettingsCb(const char* opt)
     mainMenu->settingsPos = mainMenu->menu->selectedRow;
 
     // Handle the option
-    if(mainMenuSoundOff == opt)
+    if(mainMenuSoundBgmOff == opt)
     {
         // Sound is off, turn it on
-        setIsMuted(false);
+        setBgmIsMuted(false);
     }
-    else if (mainMenuSoundOn == opt)
+    else if (mainMenuSoundBgmOn == opt)
     {
         // Sound is on, turn it off
-        setIsMuted(true);
+        setBgmIsMuted(true);
+    }
+    else if(mainMenuSoundSfxOff == opt)
+    {
+        // Sound is off, turn it on
+        setSfxIsMuted(false);
+    }
+    else if (mainMenuSoundSfxOn == opt)
+    {
+        // Sound is on, turn it off
+        setSfxIsMuted(true);
     }
     else if (mainMenuTftBrightness == opt)
     {
@@ -511,10 +548,6 @@ void mainMenuSettingsCb(const char* opt)
     else if (mainMenuMicGain == opt)
     {
         incMicGain();
-    }
-    else if (mainMenuCredits == opt)
-    {
-        switchToSwadgeMode(&modeCredits);
     }
     else if (mainMenuBack == opt)
     {

--- a/main/modes/mode_test.c
+++ b/main/modes/mode_test.c
@@ -186,7 +186,8 @@ void testEnterMode(display_t* disp)
     test->maxValue = 1;
 
     // Set the mic to listen
-    setIsMuted(false);
+    setBgmIsMuted(false);
+    setSfxIsMuted(false);
     setMicGain(7);
 
     // Play a song

--- a/main/settingsManager.c
+++ b/main/settingsManager.c
@@ -22,7 +22,8 @@
 // Variables
 //==============================================================================
 
-const char KEY_MUTE[]       = "mute";
+const char KEY_MUTE_BGM[]       = "mutebgm";
+const char KEY_MUTE_SFX[]       = "mutesfx";
 const char KEY_TFT_BRIGHT[] = "bright";
 const char KEY_MIC[]        = "mic";
 const char KEY_LED_BRIGHT[] = "led";
@@ -37,14 +38,14 @@ const char KEY_TEST[]       = "test";
 /**
  * @return true if the buzzer is muted, false if it is not
  */
-bool getIsMuted(void)
+bool getBgmIsMuted(void)
 {
     int32_t muted = false;
     // Try reading the value
-    if(false == readNvs32(KEY_MUTE, &muted))
+    if(false == readNvs32(KEY_MUTE_BGM, &muted))
     {
         // Value didn't exist, so write the default
-        setIsMuted(muted);
+        setBgmIsMuted(muted);
     }
     // Return the read value
     return (bool)muted;
@@ -56,10 +57,38 @@ bool getIsMuted(void)
  * @param isMuted true to mute the buzzer, false to turn it on
  * @return true if the setting was saved, false if it was not
  */
-bool setIsMuted(bool isMuted)
+bool setBgmIsMuted(bool isMuted)
 {
     // Write the value
-    return writeNvs32(KEY_MUTE, isMuted);
+    return writeNvs32(KEY_MUTE_BGM, isMuted);
+}
+
+/**
+ * @return true if the buzzer is muted, false if it is not
+ */
+bool getSfxIsMuted(void)
+{
+    int32_t muted = false;
+    // Try reading the value
+    if(false == readNvs32(KEY_MUTE_SFX, &muted))
+    {
+        // Value didn't exist, so write the default
+        setSfxIsMuted(muted);
+    }
+    // Return the read value
+    return (bool)muted;
+}
+
+/**
+ * Set if the buzzer is muted or not
+ *
+ * @param isMuted true to mute the buzzer, false to turn it on
+ * @return true if the setting was saved, false if it was not
+ */
+bool setSfxIsMuted(bool isMuted)
+{
+    // Write the value
+    return writeNvs32(KEY_MUTE_SFX, isMuted);
 }
 
 /**

--- a/main/settingsManager.h
+++ b/main/settingsManager.h
@@ -8,8 +8,11 @@
 // Function Prototypes
 //==============================================================================
 
-bool getIsMuted(void);
-bool setIsMuted(bool);
+bool getBgmIsMuted(void);
+bool setBgmIsMuted(bool);
+
+bool getSfxIsMuted(void);
+bool setSfxIsMuted(bool);
 
 int32_t getTftBrightness(void);
 bool incTftBrightness(void);

--- a/main/swadge_esp32.c
+++ b/main/swadge_esp32.c
@@ -376,7 +376,7 @@ void mainSwadgeTask(void* arg __attribute((unused)))
 
     // Same for CONFIG_SWADGE_DEVKIT and CONFIG_SWADGE_PROTOTYPE
     // Make sure to use a different timer than initButtons()
-    buzzer_init(GPIO_NUM_40, RMT_CHANNEL_1, TIMER_GROUP_0, TIMER_1, getIsMuted());
+    buzzer_init(GPIO_NUM_40, RMT_CHANNEL_1, TIMER_GROUP_0, TIMER_1, getBgmIsMuted(), getSfxIsMuted());
 
 #if defined(CONFIG_SWADGE_DEVKIT)
     initTouchSensor(0.2f, true, 6,


### PR DESCRIPTION
Separates single mute in BGM and SFX mutes. Tested on emulator and device, closes #117. Observed slight discrepancy on Emulator where sound settings will not take effect until Emulator is closed and re-opened, but functions normally on device.