### PR TITLE
Fix missing initialization in gallery

### DIFF
--- a/main/modes/paint/paint_gallery.c
+++ b/main/modes/paint/paint_gallery.c
@@ -13,6 +13,7 @@
 
 void paintGallerySetup(void)
 {
+    paintState->canvas.disp = paintState->disp;
     paintState->gallerySpeed = GALLERY_MIN_TIME;
     paintState->galleryTime = 0;
     paintState->galleryLoadNew = true;


### PR DESCRIPTION
Fixes gallery immediately crashing because I forgot to test it after moving draw mode's init out of the paint main menu