### PR TITLE
Paint polish and resiliency for share mode and screensaver

### DIFF
--- a/main/modes/paint/mode_paint.c
+++ b/main/modes/paint/mode_paint.c
@@ -56,6 +56,7 @@ const char menuOptCancelErase[] = "Confirm? No!";
 const char menuOptConfirmErase[] = "Confirm? Yes";
 
 const char menuOptExit[] = "Exit";
+const char menuOptBack[] = "Back";
 
 // Mode struct function declarations
 void paintEnterMode(display_t* disp);
@@ -328,7 +329,7 @@ void paintSetupNetworkMenu(bool reset)
     }
 
     addRowToMeleeMenu(paintMenu->menu, menuOptReceive);
-    addRowToMeleeMenu(paintMenu->menu, menuOptExit);
+    addRowToMeleeMenu(paintMenu->menu, menuOptBack);
 
     if (reset)
     {
@@ -378,7 +379,7 @@ void paintSetupSettingsMenu(bool reset)
     {
         addRowToMeleeMenu(paintMenu->menu, menuOptEraseData);
     }
-    addRowToMeleeMenu(paintMenu->menu, menuOptExit);
+    addRowToMeleeMenu(paintMenu->menu, menuOptBack);
 
     if (reset)
     {
@@ -445,9 +446,9 @@ void paintNetworkMenuCb(const char* opt)
         paintMenu->screen = PAINT_RECEIVE;
         switchToSwadgeMode(&modePaintReceive);
     }
-    else if (opt == menuOptExit)
+    else if (opt == menuOptBack)
     {
-        PAINT_LOGI("Selected Exit");
+        PAINT_LOGI("Selected Back");
         paintSetupMainMenu(false);
         paintMenu->screen = PAINT_MENU;
     }
@@ -498,9 +499,9 @@ void paintSettingsMenuCb(const char* opt)
         paintMenu->eraseDataSelected = false;
         paintMenu->eraseDataConfirm = false;
     }
-    else if (opt == menuOptExit)
+    else if (opt == menuOptBack)
     {
-        PAINT_LOGI("Selected Exit");
+        PAINT_LOGI("Selected Back");
         paintSetupMainMenu(false);
         paintMenu->screen = PAINT_MENU;
         return;

--- a/main/modes/paint/mode_paint.c
+++ b/main/modes/paint/mode_paint.c
@@ -138,8 +138,9 @@ void paintMainLoop(int64_t elapsedUs)
         if (paintMenu->idleTimer >= PAINT_SCREENSAVER_TIMEOUT)
         {
             PAINT_LOGI("Selected Gallery");
-            paintMenu->screen = PAINT_GALLERY;
             paintGallerySetup(paintMenu->disp, true);
+            paintGallery->returnScreen = paintMenu->screen;
+            paintMenu->screen = PAINT_GALLERY;
         }
         else
         {
@@ -526,7 +527,28 @@ void paintReturnToMainMenu(void)
         break;
 
         case PAINT_GALLERY:
-            paintGalleryCleanup();
+            if (paintGallery->screensaverMode)
+            {
+                paintMenu->screen = paintGallery->returnScreen;
+                paintGalleryCleanup();
+                if (paintMenu->screen == PAINT_MENU)
+                {
+                    paintSetupMainMenu(false);
+                }
+                else if (paintMenu->screen == PAINT_NETWORK_MENU)
+                {
+                    paintSetupNetworkMenu(false);
+                }
+                else if (paintMenu->screen == PAINT_SETTINGS_MENU)
+                {
+                    paintSetupSettingsMenu(false);
+                }
+                return;
+            }
+            else
+            {
+                paintGalleryCleanup();
+            }
         break;
 
         case PAINT_HELP:

--- a/main/modes/paint/paint_common.h
+++ b/main/modes/paint/paint_common.h
@@ -341,6 +341,7 @@ typedef struct
 
     bool galleryLoadNew;
     bool screensaverMode;
+    paintScreen_t returnScreen;
 
     uint8_t galleryScale;
 } paintGallery_t;

--- a/main/modes/paint/paint_common.h
+++ b/main/modes/paint/paint_common.h
@@ -278,6 +278,7 @@ typedef struct
     int32_t index;
 
     font_t toolbarFont;
+    wsg_t arrowWsg;
 
     // The save slot being displayed / shared
     uint8_t shareSaveSlot;
@@ -306,6 +307,7 @@ typedef struct
 
     // Time for the progress bar timer
     int64_t shareTime;
+    int64_t timeSincePacket;
 
     // True if we are the sender, false if not
     bool isSender;

--- a/main/modes/paint/paint_share.c
+++ b/main/modes/paint/paint_share.c
@@ -33,12 +33,15 @@
 #define SHARE_LEFT_MARGIN 10
 #define SHARE_RIGHT_MARGIN 10
 #define SHARE_TOP_MARGIN 25
-#define SHARE_BOTTOM_MARGIN 5
+#define SHARE_BOTTOM_MARGIN 25
 
 #define SHARE_PROGRESS_LEFT 30
 #define SHARE_PROGESS_RIGHT 30
 
 #define SHARE_PROGRESS_SPEED 25000
+
+// Reset after 5 seconds without a packet
+#define CONN_LOST_TIMEOUT 5000000
 
 #define SHARE_BG_COLOR c444
 #define SHARE_CANVAS_BORDER c000
@@ -51,7 +54,6 @@ const uint8_t SHARE_PACKET_PIXEL_DATA = 1;
 const uint8_t SHARE_PACKET_PIXEL_REQUEST = 2;
 const uint8_t SHARE_PACKET_RECEIVE_COMPLETE = 3;
 const uint8_t SHARE_PACKET_ABORT = 4;
-const uint8_t SHARE_PACKET_HELLO = 5;
 
 // The canvas data packet has PAINT_MAX_COLORS bytes of palette, plus 2 uint16_ts of width/height. Also 1 for size
 const uint8_t PACKET_LEN_CANVAS_DATA = sizeof(uint8_t) * PAINT_MAX_COLORS + sizeof(uint16_t) * 2;
@@ -59,6 +61,9 @@ const uint8_t PACKET_LEN_CANVAS_DATA = sizeof(uint8_t) * PAINT_MAX_COLORS + size
 static const char strOverwriteSlot[] = "Overwrite Slot %d";
 static const char strEmptySlot[] = "Save in Slot %d";
 static const char strShareSlot[] = "Share Slot %d";
+static const char strControlsShare[] = "A to Share";
+static const char strControlsSave[] = "A to Save";
+static const char strControlsCancel[] = "B to Cancel";
 
 paintShare_t* paintShare;
 
@@ -86,7 +91,6 @@ void paintShareDeinitP2p(void);
 void paintShareMsgSendOk(void);
 void paintShareMsgSendFail(void);
 
-void paintShareSendHello(void);
 void paintShareSendPixelRequest(void);
 void paintShareSendReceiveComplete(void);
 void paintShareSendAbort(void);
@@ -102,7 +106,6 @@ void paintShareRetry(void);
 void paintShareDoLoad(void);
 void paintShareDoSave(void);
 
-bool paintShareDetectWrongMode(void);
 
 // Use a different swadge mode so the main game doesn't take as much battery
 swadgeMode modePaintShare =
@@ -149,7 +152,8 @@ void paintShareInitP2p(void)
     paintShare->shareNewPacket = false;
 
     p2pDeinit(&paintShare->p2pInfo);
-    p2pInitialize(&paintShare->p2pInfo, 'P', paintShareP2pConnCb, paintShareP2pMsgRecvCb, -15);
+    p2pInitialize(&paintShare->p2pInfo, isSender() ? 'P' : 'Q', paintShareP2pConnCb, paintShareP2pMsgRecvCb, -15);
+    p2pSetAsymmetric(&paintShare->p2pInfo, isSender() ? 'Q' : 'P');
     p2pStartConnection(&paintShare->p2pInfo);
 }
 
@@ -177,6 +181,20 @@ void paintShareCommonSetup(display_t* disp)
         PAINT_LOGE("Unable to load font!");
     }
 
+    if (!loadWsg("arrow12.wsg", &paintShare->arrowWsg))
+    {
+        PAINT_LOGE("Unable to load arrow WSG!");
+    }
+    else
+    {
+        for (uint16_t i = 0; i < paintShare->arrowWsg.h * paintShare->arrowWsg.w; i++)
+        {
+            // Recolor the arrow to black
+            if (paintShare->arrowWsg.px[i] != cTransparent) {
+                paintShare->arrowWsg.px[i] = c000;
+            }
+        }
+    }
 
     // Set the display
     paintShare->canvas.disp = paintShare->disp = disp;
@@ -284,7 +302,6 @@ void paintShareRenderProgressBar(int64_t elapsedUs, uint16_t x, uint16_t y, uint
         // (WIDTH / ((totalPacketNum + 1) * 4)) * (currentPacketNum) * 4 + (sent: 2, acked: 3, req'd: 4)
         uint16_t maxProgress = ((paintShare->canvas.h * paintShare->canvas.w + PAINT_SHARE_PX_PER_PACKET - 1) / PAINT_SHARE_PX_PER_PACKET + 1);
 
-        PAINT_LOGD("Progress: %02d / %02d", progress, maxProgress);
         // Now, we just draw a box at (progress * (width) / maxProgress)
         uint16_t size = (progress > maxProgress ? maxProgress : progress) * w / maxProgress;
         plotRectFilled(paintShare->disp, x + 1, y + 1, x + size, y + h, SHARE_PROGRESS_FG);
@@ -348,22 +365,29 @@ void paintRenderShareMode(int64_t elapsedUs)
     }
 
     char text[32];
+    const char *bottomText = NULL;
+    bool arrows = false;
 
     switch (paintShare->shareState)
     {
         case SHARE_RECV_SELECT_SLOT:
         {
+            arrows = true;
+            bottomText = strControlsSave;
             snprintf(text, sizeof(text), paintGetSlotInUse(paintShare->index, paintShare->shareSaveSlot) ? strOverwriteSlot : strEmptySlot, paintShare->shareSaveSlot + 1);
             break;
         }
         case SHARE_SEND_SELECT_SLOT:
         {
+            arrows = true;
+            bottomText = strControlsShare;
             snprintf(text, sizeof(text), strShareSlot, paintShare->shareSaveSlot + 1);
             break;
         }
         case SHARE_SEND_WAIT_FOR_CONN:
         case SHARE_RECV_WAIT_FOR_CONN:
         {
+            bottomText = strControlsCancel;
             snprintf(text, sizeof(text), "Connecting...");
             break;
         }
@@ -400,7 +424,29 @@ void paintRenderShareMode(int64_t elapsedUs)
 
     // Draw the text over the progress bar
     uint16_t w = textWidth(&paintShare->toolbarFont, text);
-    drawText(paintShare->disp, &paintShare->toolbarFont, c000, text, (paintShare->disp->w - w) / 2, 4);
+    uint16_t y = (SHARE_TOP_MARGIN - paintShare->toolbarFont.h) / 2;
+    drawText(paintShare->disp, &paintShare->toolbarFont, c000, text, (paintShare->disp->w - w) / 2, y);
+    if (arrows)
+    {
+        // flip instead of using rotation to prevent 1px offset
+        drawWsg(paintShare->disp, &paintShare->arrowWsg, (paintShare->disp->w - w) / 2 - paintShare->arrowWsg.w - 6, y + (paintShare->toolbarFont.h - paintShare->arrowWsg.h) / 2, false, true, 90);
+        drawWsg(paintShare->disp, &paintShare->arrowWsg, (paintShare->disp->w - w) / 2 + w + 6, y + (paintShare->toolbarFont.h - paintShare->arrowWsg.h) / 2, false, false, 90);
+    }
+
+    if (bottomText != NULL)
+    {
+        if (paintShare->canvas.h > 0 && paintShare->canvas.yScale > 0)
+        {
+            y = paintShare->canvas.y + paintShare->canvas.h * paintShare->canvas.yScale + (paintShare->disp->h - paintShare->canvas.y - paintShare->canvas.h * paintShare->canvas.yScale - paintShare->toolbarFont.h) / 2;
+        }
+        else
+        {
+            y = paintShare->disp->h - paintShare->toolbarFont.h - 8;
+        }
+
+        w = textWidth(&paintShare->toolbarFont, bottomText);
+        drawText(paintShare->disp, &paintShare->toolbarFont, c000, bottomText, (paintShare->disp->w - w) / 2, y);
+    }
 }
 
 void paintShareSendCanvas(void)
@@ -576,15 +622,6 @@ void paintShareSendAbort(void)
     paintShare->shareUpdateScreen = true;
 }
 
-void paintShareSendHello(void)
-{
-    paintShare->sharePacket[0] = SHARE_PACKET_HELLO;
-    paintShare->sharePacket[1] = isSender() ? 1 : 0;
-    paintShare->sharePacketLen = 2;
-    p2pSendMsg(&paintShare->p2pInfo, paintShare->sharePacket, paintShare->sharePacketLen, paintShareP2pSendCb);
-    paintShare->shareUpdateScreen = true;
-}
-
 void paintShareMsgSendOk(void)
 {
     paintShare->shareUpdateScreen = true;
@@ -659,6 +696,7 @@ void paintShareMsgSendFail(void)
 
 void paintBeginShare(void)
 {
+    paintShareInitP2p();
     paintShare->shareState = SHARE_SEND_WAIT_FOR_CONN;
 
     paintShare->shareSeqNum = 0;
@@ -670,9 +708,22 @@ void paintShareExitMode(void)
 {
     p2pDeinit(&paintShare->p2pInfo);
     freeFont(&paintShare->toolbarFont);
+    freeWsg(&paintShare->arrowWsg);
+
     free(paintShare);
 
     paintShare = NULL;
+}
+
+void paintShareCheckForTimeout(void)
+{
+    if (paintShare->timeSincePacket >= CONN_LOST_TIMEOUT)
+    {
+        paintShare->timeSincePacket = 0;
+        PAINT_LOGD("Conn loss detected, resetting");
+        paintShare->shareState = isSender() ? SHARE_SEND_WAIT_FOR_CONN : SHARE_RECV_WAIT_FOR_CONN;
+        paintShareInitP2p();
+    }
 }
 
 // Go back to the previous state so we retry the last thing
@@ -740,6 +791,14 @@ void paintShareMainLoop(int64_t elapsedUs)
     }
 
     paintShare->shareTime += elapsedUs;
+    if (paintShare->shareNewPacket)
+    {
+        paintShare->timeSincePacket = 0;
+    }
+    else
+    {
+        paintShare->timeSincePacket += elapsedUs;
+    }
 
     switch (paintShare->shareState)
     {
@@ -766,6 +825,7 @@ void paintShareMainLoop(int64_t elapsedUs)
 
         case SHARE_SEND_WAIT_CANVAS_DATA_ACK:
         {
+            paintShareCheckForTimeout();
             break;
         }
 
@@ -786,6 +846,10 @@ void paintShareMainLoop(int64_t elapsedUs)
                     paintShare->shareUpdateScreen = true;
                 }
             }
+            else
+            {
+                paintShareCheckForTimeout();
+            }
             break;
         }
 
@@ -797,6 +861,7 @@ void paintShareMainLoop(int64_t elapsedUs)
 
         case SHARE_SEND_WAIT_PIXEL_DATA_ACK:
         {
+            // Don't need to check for timeout! p2pConnection will handle it for acks
             break;
         }
 
@@ -805,8 +870,6 @@ void paintShareMainLoop(int64_t elapsedUs)
             paintShareDeinitP2p();
             break;
         }
-
-
 
         case SHARE_RECV_WAIT_FOR_CONN:
         {
@@ -825,6 +888,10 @@ void paintShareMainLoop(int64_t elapsedUs)
             {
                 paintShareHandleCanvas();
             }
+            else
+            {
+                paintShareCheckForTimeout();
+            }
             paintShare->shareUpdateScreen = true;
 
             break;
@@ -835,6 +902,10 @@ void paintShareMainLoop(int64_t elapsedUs)
             if (paintShare->shareNewPacket)
             {
                 paintShareHandlePixels();
+            }
+            else
+            {
+                paintShareCheckForTimeout();
             }
             paintShare->shareUpdateScreen = true;
             break;
@@ -1022,7 +1093,6 @@ void paintShareP2pConnCb(p2pInfo* p2p, connectionEvt_t evt)
     {
         case CON_STARTED:
         PAINT_LOGD("CON_STARTED");
-        //paintShareSendHello();
         break;
 
         case RX_GAME_START_ACK:
@@ -1047,66 +1117,26 @@ void paintShareP2pConnCb(p2pInfo* p2p, connectionEvt_t evt)
                 PAINT_LOGD("state = SHARE_RECV_WAIT_CANVAS_DATA");
                 paintShare->shareState = SHARE_RECV_WAIT_CANVAS_DATA;
             }
+
             break;
         }
 
         case CON_LOST:
-        PAINT_LOGD("CON_LOST");
-        paintShareDeinitP2p();
-        if (isSender())
         {
-            paintShare->shareState = SHARE_SEND_WAIT_FOR_CONN;
-        }
-        else
-        {
-            paintShare->shareState = SHARE_RECV_WAIT_FOR_CONN;
-        }
-        break;
-    }
-}
-
-bool paintShareDetectWrongMode(void)
-{
-    if (isSender())
-    {
-        if (paintShare->sharePacket[0] == SHARE_PACKET_CANVAS_DATA || paintShare->sharePacket[0] == SHARE_PACKET_PIXEL_DATA || paintShare->sharePacket[0] == SHARE_PACKET_ABORT || (paintShare->sharePacket[0] == SHARE_PACKET_HELLO && paintShare->sharePacket[1] == 1))
-        {
-            if (p2pGetPlayOrder(&paintShare->p2pInfo) == GOING_FIRST)
-            {
-                paintShare->shareState = SHARE_SEND_SELECT_SLOT;
-                paintShare->shareUpdateScreen = true;
-            }
-            else
+            PAINT_LOGD("CON_LOST");
+            paintShareInitP2p();
+            if (isSender())
             {
                 paintShare->shareState = SHARE_SEND_WAIT_FOR_CONN;
             }
-
-            if (paintShare->sharePacket[0] != SHARE_PACKET_ABORT)
+            else
             {
-                // if we aren't doing this because of an abort packet, send one to the other side
-                paintShareSendAbort();
+                paintShare->shareState = SHARE_RECV_WAIT_FOR_CONN;
             }
-            paintShareDeinitP2p();
-            return true;
+
+            break;
         }
     }
-    else
-    {
-        if (paintShare->sharePacket[0] == SHARE_PACKET_PIXEL_REQUEST || paintShare->sharePacket[0] == SHARE_PACKET_ABORT || (paintShare->sharePacket[0] == SHARE_PACKET_HELLO && paintShare->sharePacket[1] == 0))
-        {
-            paintShare->shareState = SHARE_RECV_WAIT_FOR_CONN;
-            paintShare->shareUpdateScreen = true;
-
-            if (paintShare->sharePacket[0] != SHARE_PACKET_ABORT)
-            {
-                paintShareSendAbort();
-            }
-            paintShareDeinitP2p();
-            return true;
-        }
-    }
-
-    return false;
 }
 
 void paintShareP2pMsgRecvCb(p2pInfo* p2p, const uint8_t* payload, uint8_t len)
@@ -1115,16 +1145,8 @@ void paintShareP2pMsgRecvCb(p2pInfo* p2p, const uint8_t* payload, uint8_t len)
     PAINT_LOGV("Receiving %d bytes via P2P callback", len);
     memcpy(paintShare->sharePacket, payload, len);
 
-    if (!paintShareDetectWrongMode())
-    {
-        PAINT_LOGV("RECEIVED DATA:");
-        for (uint8_t i = 0; i < len; i+= 4)
-        {
-            PAINT_LOGV("%04d %02x %02x %02x %02x", i, payload[i], payload[i+1], payload[i+2], payload[i+3]);
-        }
-        paintShare->sharePacketLen = len;
-        paintShare->shareNewPacket = true;
-    }
+    paintShare->sharePacketLen = len;
+    paintShare->shareNewPacket = true;
 }
 
 void paintShareDoLoad(void)

--- a/main/p2pConnection.h
+++ b/main/p2pConnection.h
@@ -80,6 +80,7 @@ typedef struct _p2pInfo
 {
     // Messages that every mode uses
     uint8_t modeId;
+    uint8_t incomingModeId;
     p2pConMsg_t conMsg;
     p2pDataMsg_t ackMsg;
     p2pCommonHeader_t startMsg;
@@ -141,6 +142,7 @@ typedef struct
 
 void p2pInitialize(p2pInfo* p2p, uint8_t modeId, p2pConCbFn conCbFn,
                    p2pMsgRxCbFn msgRxCbFn, int8_t connectionRssi);
+void p2pSetAsymmetric(p2pInfo* p2p, uint8_t incomingModeId);
 void p2pDeinit(p2pInfo* p2p);
 
 void p2pStartConnection(p2pInfo* p2p);


### PR DESCRIPTION
Share mode:
* Adds a way for P2P connections to connect with a specific other mode ID only
* Adds arrows around the slot selection text
* Adds bottom text with the important controls when appropriate
* Gets rid of the logic that (sometimes) detected if two sharers or receivers were connected to each other
* Triggers a reconnect after waiting 5 seconds without receiving an expected packet

Other stuff:
* Changes "Exit" back to "Back" for just the submenus, leaving the top level as "Exit", like I meant to do the first time
* Doesn't reset the menu when returning from the gallery screensaver