### PR TITLE
Fix off-by-one in rotatePixel()

### DIFF
--- a/main/display/display.c
+++ b/main/display/display.c
@@ -300,21 +300,21 @@ static void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width
         // (x, y) -> (y, -x)
         int16_t tmp = wx;
         wx = wy;
-        wy = width - 1 - (tmp + (width / 2)) - (width / 2);
+        wy = width - 1 - tmp - 2 * (width / 2);
         rotateDeg -= 270;
     }
     else if(rotateDeg >= 180)
     {
         // (x, y) -> (-x, -y)
-        wx = width - 1 - (wx + (width / 2)) - (width / 2);
-        wy = height - 1 - (wy + (height / 2)) - (height / 2);
+        wx = width - 1 - wx - 2 * (width / 2);
+        wy = height - 1 - wy - 2 * (height / 2);
         rotateDeg -= 180;
     }
     else if(rotateDeg >= 90)
     {
         // (x, y) -> (-y, x)
         int16_t tmp = wx;
-        wx = height - 1 - (wy + (height / 2)) - (height / 2);
+        wx = height - 1 - wy - 2 * (height / 2);
         wy = tmp;
         rotateDeg -= 90;
     }

--- a/main/display/display.c
+++ b/main/display/display.c
@@ -300,21 +300,21 @@ static void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width
         // (x, y) -> (y, -x)
         int16_t tmp = wx;
         wx = wy;
-        wy = -tmp;
+        wy = width - 1 - (tmp + (width / 2)) - (width / 2);
         rotateDeg -= 270;
     }
     else if(rotateDeg >= 180)
     {
         // (x, y) -> (-x, -y)
-        wx = -wx;
-        wy = -wy;
+        wx = width - 1 - (wx + (width / 2)) - (width / 2);
+        wy = height - 1 - (wy + (height / 2)) - (height / 2);
         rotateDeg -= 180;
     }
     else if(rotateDeg >= 90)
     {
         // (x, y) -> (-y, x)
         int16_t tmp = wx;
-        wx = -wy;
+        wx = height - 1 - (wy + (height / 2)) - (height / 2);
         wy = tmp;
         rotateDeg -= 90;
     }

--- a/main/display/display.c
+++ b/main/display/display.c
@@ -290,9 +290,12 @@ static void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width
     // See http://datagenetics.com/blog/august32013/index.html
     // See https://graphicsinterface.org/wp-content/uploads/gi1986-15.pdf
 
+    int32_t tx = -(width / 2);
+    int32_t ty = -(height / 2);
+
     // Center around (0, 0)
-    wx -= (width / 2);
-    wy -= (height / 2);
+    wx += tx;
+    wy += ty;
 
     // First rotate to the nearest 90 degree boundary, which is trivial
     if(rotateDeg >= 270)
@@ -300,21 +303,21 @@ static void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width
         // (x, y) -> (y, -x)
         int16_t tmp = wx;
         wx = wy;
-        wy = -2 * (width / 2) - tmp + width - 1;
+        wy = 2 * tx - tmp + width - 1;
         rotateDeg -= 270;
     }
     else if(rotateDeg >= 180)
     {
         // (x, y) -> (-x, -y)
-        wx = -2 * (width / 2) - wx + width - 1;
-        wy = -2 * (height / 2) - wy + height - 1;
+        wx = 2 * tx - wx + width - 1;
+        wy = 2 * ty - wy + height - 1;
         rotateDeg -= 180;
     }
     else if(rotateDeg >= 90)
     {
         // (x, y) -> (-y, x)
         int16_t tmp = wx;
-        wx = -2 * (height / 2) - wy + height - 1;
+        wx = 2 * ty - wy + height - 1;
         wy = tmp;
         rotateDeg -= 90;
     }
@@ -335,8 +338,8 @@ static void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width
     }
 
     // Return pixel to original position
-    wx += (width / 2);
-    wy += (height / 2);
+    wx -= tx;
+    wy -= ty;
 
     *x = wx;
     *y = wy;

--- a/main/display/display.c
+++ b/main/display/display.c
@@ -300,21 +300,21 @@ static void rotatePixel(int16_t* x, int16_t* y, int16_t rotateDeg, int16_t width
         // (x, y) -> (y, -x)
         int16_t tmp = wx;
         wx = wy;
-        wy = width - 1 - tmp - 2 * (width / 2);
+        wy = -2 * (width / 2) - tmp + width - 1;
         rotateDeg -= 270;
     }
     else if(rotateDeg >= 180)
     {
         // (x, y) -> (-x, -y)
-        wx = width - 1 - wx - 2 * (width / 2);
-        wy = height - 1 - wy - 2 * (height / 2);
+        wx = -2 * (width / 2) - wx + width - 1;
+        wy = -2 * (height / 2) - wy + height - 1;
         rotateDeg -= 180;
     }
     else if(rotateDeg >= 90)
     {
         // (x, y) -> (-y, x)
         int16_t tmp = wx;
-        wx = height - 1 - wy - 2 * (height / 2);
+        wx = -2 * (height / 2) - wy + height - 1;
         wy = tmp;
         rotateDeg -= 90;
     }


### PR DESCRIPTION
Translates the pixels back into the sprite coordinate space, flips them according to the sprite dimensions, then translates them back