### PR TITLE
Fix incorrect LED count in picrossVictoryLEDs

### DIFF
--- a/main/modes/picross/mode_picross.c
+++ b/main/modes/picross/mode_picross.c
@@ -1632,6 +1632,6 @@ void picrossVictoryLEDs(uint32_t tElapsedUs, uint32_t arg, bool reset)
     // Output the LED data, actually turning them on
     if(ledsUpdated)
     {
-        setLeds(leds, sizeof(leds));
+        setLeds(leds, NUM_LEDS);
     }
 }


### PR DESCRIPTION
Fixes a stack overrun from using `sizeof(leds)` instead of `sizeof(leds) / sizeof(led_t)` or `NUM_LEDS` that was found by `asan`