### PR TITLE
Always save the entire picrossVictoryData_t to NVS

### DIFF
--- a/main/modes/picross/mode_picross.c
+++ b/main/modes/picross/mode_picross.c
@@ -1592,7 +1592,7 @@ void saveCompletedOnSelectedLevel(bool completed)
     picrossVictoryData_t* victData = calloc(1,size);//zero out. if data doesnt exist, then its been correctly initialized to all 0s. 
     readNvsBlob(picrossCompletedLevelData,victData,&size);
     victData->victories[(int)*&p->selectedLevel.index] = completed;
-    writeNvsBlob(picrossCompletedLevelData,victData,size);
+    writeNvsBlob(picrossCompletedLevelData, victData, sizeof(picrossVictoryData_t));
     free(victData);
 }
 


### PR DESCRIPTION
Fixes a bug that would likely only happen on dev swadges. The size of the existing blob was always used, even if it was smaller than the actual struct. Since the first time I played pi-cross on this swadge and the blob was created, there were only 21 levels, so ever since only the first 21 levels were getting saved.