### PR TITLE
Fighter fixes

### DIFF
--- a/assets/fighter/bf/bf.json
+++ b/assets/fighter/bf/bf.json
@@ -1,6 +1,7 @@
 {
    "name":"Bigg Funkus",
    "gravity":8192,
+   "weight":1536,
    "jump_velo":-15360,
    "run_accel":13000,
    "run_decel":13000,

--- a/assets/fighter/bf/bf.json
+++ b/assets/fighter/bf/bf.json
@@ -85,7 +85,7 @@
                      "damage":9,
                      "knockback_x":1000,
                      "knockback_y":-8000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -122,7 +122,7 @@
                      "damage":12,
                      "knockback_x":20000,
                      "knockback_y":-10000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             },
@@ -142,7 +142,7 @@
                      "damage":12,
                      "knockback_x":-20000,
                      "knockback_y":-10000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -180,7 +180,7 @@
                      "damage":9,
                      "knockback_x":9000,
                      "knockback_y":-3000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -217,7 +217,7 @@
                      "damage":9,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -255,7 +255,7 @@
                      "damage":9,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10,
+                     "hitstun":33,
                      "isProjectile":true,
                      "projectileSprite":{
                         "sprite":"bnap.wsg"
@@ -303,7 +303,7 @@
                      "damage":9,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10,
+                     "hitstun":33,
                      "isProjectile":true,
                      "projectileSprite":{
                         "sprite":"bnap.wsg"
@@ -351,7 +351,7 @@
                      "damage":9,
                      "knockback_x":8000,
                      "knockback_y":-4000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -389,7 +389,7 @@
                      "damage":9,
                      "knockback_x":-9000,
                      "knockback_y":-4000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -430,7 +430,7 @@
                      "damage":10,
                      "knockback_x":-4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":14,
@@ -440,7 +440,7 @@
                      "damage":10,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             },
@@ -462,7 +462,7 @@
                      "damage":10,
                      "knockback_x":-4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":14,
@@ -472,7 +472,7 @@
                      "damage":10,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             },
@@ -494,7 +494,7 @@
                      "damage":10,
                      "knockback_x":-4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":14,
@@ -504,7 +504,7 @@
                      "damage":10,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             },
@@ -526,7 +526,7 @@
                      "damage":10,
                      "knockback_x":-4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":14,
@@ -536,7 +536,7 @@
                      "damage":10,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -575,7 +575,7 @@
                      "damage":9,
                      "knockback_x":500,
                      "knockback_y":8000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }

--- a/assets/fighter/kd/kd.json
+++ b/assets/fighter/kd/kd.json
@@ -1,6 +1,7 @@
 {
    "name":"King Donut",
    "gravity":8192,
+   "weight":1024,
    "jump_velo":-15360,
    "run_accel":13000,
    "run_decel":13000,

--- a/assets/fighter/kd/kd.json
+++ b/assets/fighter/kd/kd.json
@@ -85,7 +85,7 @@
                      "damage":9,
                      "knockback_x":1000,
                      "knockback_y":-8000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             },
@@ -105,7 +105,7 @@
                      "damage":12,
                      "knockback_x":5000,
                      "knockback_y":-10000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -142,7 +142,7 @@
                      "damage":12,
                      "knockback_x":-10000,
                      "knockback_y":3000,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":30,
@@ -152,7 +152,7 @@
                      "damage":10,
                      "knockback_x":8000,
                      "knockback_y":3000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -190,7 +190,7 @@
                      "damage":9,
                      "knockback_x":9000,
                      "knockback_y":-3000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -227,7 +227,7 @@
                      "damage":18,
                      "knockback_x":9000,
                      "knockback_y":-3000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -264,7 +264,7 @@
                      "damage":9,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10,
+                     "hitstun":33,
                      "isProjectile":true,
                      "projectileSprite":{
                         "sprite":"kngp.wsg"
@@ -311,7 +311,7 @@
                      "damage":9,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10,
+                     "hitstun":33,
                      "isProjectile":true,
                      "projectileSprite":{
                         "sprite":"kngp.wsg"
@@ -358,7 +358,7 @@
                      "damage":9,
                      "knockback_x":8000,
                      "knockback_y":-4000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -396,7 +396,7 @@
                      "damage":9,
                      "knockback_x":-9000,
                      "knockback_y":-4000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -436,7 +436,7 @@
                      "damage":10,
                      "knockback_x":0,
                      "knockback_y":-7000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             },
@@ -458,7 +458,7 @@
                      "damage":9,
                      "knockback_x":500,
                      "knockback_y":8000,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":23,
@@ -468,7 +468,7 @@
                      "damage":9,
                      "knockback_x":500,
                      "knockback_y":8000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -507,7 +507,7 @@
                      "damage":9,
                      "knockback_x":500,
                      "knockback_y":8000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }

--- a/assets/fighter/sb/sb.json
+++ b/assets/fighter/sb/sb.json
@@ -1,6 +1,7 @@
 {
    "name":"Sandbag",
    "gravity":8192,
+   "weight":1024,
    "run_decel":13000,
    "size_x":22,
    "size_y":26,

--- a/assets/fighter/sn/sn.json
+++ b/assets/fighter/sn/sn.json
@@ -85,7 +85,7 @@
                      "damage":9,
                      "knockback_x":1000,
                      "knockback_y":-8000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -122,7 +122,7 @@
                      "damage":12,
                      "knockback_x":10000,
                      "knockback_y":3000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -160,7 +160,7 @@
                      "damage":9,
                      "knockback_x":9000,
                      "knockback_y":-3000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -197,7 +197,7 @@
                      "damage":18,
                      "knockback_x":9000,
                      "knockback_y":-3000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -234,7 +234,7 @@
                      "damage":9,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10,
+                     "hitstun":33,
                      "isProjectile":true,
                      "projectileSprite":{
                         "sprite":"sngp.wsg"
@@ -281,7 +281,7 @@
                      "damage":9,
                      "knockback_x":4000,
                      "knockback_y":-2000,
-                     "hitstun":10,
+                     "hitstun":33,
                      "isProjectile":true,
                      "projectileSprite":{
                         "sprite":"sngp.wsg"
@@ -328,7 +328,7 @@
                      "damage":9,
                      "knockback_x":8000,
                      "knockback_y":-4000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -366,7 +366,7 @@
                      "damage":9,
                      "knockback_x":-9000,
                      "knockback_y":-4000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -406,7 +406,7 @@
                      "damage":10,
                      "knockback_x":-4000,
                      "knockback_y":0,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":-9,
@@ -416,7 +416,7 @@
                      "damage":10,
                      "knockback_x":0,
                      "knockback_y":-4000,
-                     "hitstun":10
+                     "hitstun":33
                   },
                   {
                      "relativePos_x":26,
@@ -426,7 +426,7 @@
                      "damage":10,
                      "knockback_x":4000,
                      "knockback_y":0,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }
@@ -465,7 +465,7 @@
                      "damage":9,
                      "knockback_x":500,
                      "knockback_y":8000,
-                     "hitstun":10
+                     "hitstun":33
                   }
                ]
             }

--- a/assets/fighter/sn/sn.json
+++ b/assets/fighter/sn/sn.json
@@ -1,6 +1,7 @@
 {
    "name":"Sunny McShreds",
    "gravity":8192,
+   "weight":512,
    "jump_velo":-15360,
    "run_accel":13000,
    "run_decel":13000,

--- a/emu.mk
+++ b/emu.mk
@@ -113,6 +113,9 @@ CFLAGS_WARNINGS_EXTRA = \
 # Defines
 ################################################################################
 
+# Create a variable with the git hash and branch name
+GIT_HASH  = \"$(shell git rev-parse --short HEAD)\"
+
 # Used by the ESP SDK
 DEFINES_LIST = \
 	CONFIG_GC9307_240x280=y \
@@ -134,6 +137,7 @@ DEFINES_LIST = \
 	CONFIG_TFT_MIN_BRIGHTNESS=10 \
 	SOC_TIMER_GROUP_TIMERS_PER_GROUP=2 \
 	SOC_TIMER_GROUPS=2 \
+	GIT_SHA1=${GIT_HASH}
 
 DEFINES = $(patsubst %, -D%, $(DEFINES_LIST))
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -100,3 +100,13 @@ endfunction()
 # the target with 'idf.py -p PORT flash'.
 spiffs_file_preprocessor()
 spiffs_create_partition_image(storage ../spiffs_image FLASH_IN_PROJECT)
+
+
+execute_process(
+    COMMAND git rev-parse --short HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE VERSION_SHA1 )
+
+string(STRIP ${VERSION_SHA1} VERSION_SHA1)
+
+add_definitions( -DGIT_SHA1="${VERSION_SHA1}" )

--- a/main/modes/fighter/fighter_json.c
+++ b/main/modes/fighter/fighter_json.c
@@ -765,10 +765,7 @@ int32_t parseJsonAttackFrameHitbox(char* jsonStr, jsmntok_t* toks, int32_t tokId
                 tokIdx++;
                 // Convert ms to frames
                 hbx->hitstun = jsonInteger(jsonStr, toks[tokIdx]) / FRAME_TIME_MS;
-                if(0 == hbx->hitstun)
-                {
-                    hbx->hitstun = 1;
-                }
+                // Allow 0 frames hitstun
                 tokIdx++;
                 numFieldsParsed++;
             }

--- a/main/modes/fighter/fighter_json.c
+++ b/main/modes/fighter/fighter_json.c
@@ -259,6 +259,20 @@ int32_t parseJsonFighter(char* jsonStr, jsmntok_t* toks, int32_t tokIdx, namedSp
                 tokIdx++;
                 numFieldsParsed++;
             }
+            else if(0 == jsoneq(jsonStr, &toks[tokIdx], "weight"))
+            {
+                tokIdx++;
+                if(0 < ftr->weight && ftr->weight < 2048)
+                {
+                    ftr->weight = 2048 - jsonInteger(jsonStr, toks[tokIdx]);
+                }
+                else
+                {
+                    ftr->weight = 1024;
+                }
+                tokIdx++;
+                numFieldsParsed++;
+            }
             else if(0 == jsoneq(jsonStr, &toks[tokIdx], "jump_velo"))
             {
                 tokIdx++;

--- a/main/modes/fighter/fighter_menu.c
+++ b/main/modes/fighter/fighter_menu.c
@@ -24,6 +24,9 @@
 // Defines
 //==============================================================================
 
+#define VER_LEN 7
+#define FTR_VERSION "221112a" // must be seven chars! yymmddl
+
 #define FIGHTER_MENU_IDLE_US (1000000 * 15)
 
 //==============================================================================
@@ -1388,7 +1391,7 @@ void fighterP2pMsgRxCbFn(p2pInfo* p2p, const uint8_t* payload, uint8_t len)
             // Check what was received
             if(payload[0] == VERSION_MSG)
             {
-                if(0 == memcmp(&payload[1], GIT_SHA1, 7))
+                if(0 == memcmp(&payload[1], FTR_VERSION, VER_LEN))
                 {
                     // Connection established, show character select screen
                     setFighterMultiplayerCharSelMenu(true);
@@ -1529,8 +1532,8 @@ void fighterCheckGameBegin(void)
  */
 void fighterSendVersionToOther(void)
 {
-    uint8_t payload[8] = {VERSION_MSG};
-    memcpy(&payload[1], GIT_SHA1, 7);
+    uint8_t payload[1 + VER_LEN] = {VERSION_MSG};
+    memcpy(&payload[1], FTR_VERSION, VER_LEN);
     // Send button state to the other swawdge
     p2pSendMsg(&fm->p2p, payload, sizeof(payload), fighterP2pMsgTxCbFn);
     fm->lastSentMsg = VERSION_MSG;

--- a/main/modes/fighter/fighter_menu.c
+++ b/main/modes/fighter/fighter_menu.c
@@ -43,6 +43,7 @@ typedef enum
 
 typedef enum
 {
+    VERSION_MSG,
     CHAR_SEL_MSG,
     STAGE_SEL_MSG,
     BUTTON_INPUT_MSG,
@@ -135,6 +136,8 @@ void fighterP2pMsgRxCbFn(p2pInfo* p2p, const uint8_t* payload, uint8_t len);
 void fighterP2pMsgTxCbFn(p2pInfo* p2p, messageStatus_t status, const uint8_t* data, uint8_t dataLen);
 void fighterCheckGameBegin(void);
 
+void fighterSendVersionToOther(void);
+
 //==============================================================================
 // Variables
 //==============================================================================
@@ -176,6 +179,9 @@ const char str_searching_for[] = "Searching For";
 const char str_another_swadge[] = "Another Swadge";
 
 const char str_please_connect[] = "Please Connect";
+
+const char str_version_mismatch[] = "Version Mismatch";
+const char str_visit_swadge_com[] = "Visit swadge.com";
 
 // Must match order of fightingCharacter_t
 const char* charNames[3] =
@@ -436,9 +442,10 @@ void fighterButtonCb(buttonEvt_t* evt)
             if(evt->down && ((START == evt->button) || (SELECT == evt->button) || (BTN_B == evt->button)))
             {
                 p2pDeinit(&(fm->p2p));
-                if(str_another_swadge == fm->ftrConnectingStringBottom)
+                if( (str_another_swadge == fm->ftrConnectingStringBottom) ||
+                        (str_visit_swadge_com == fm->ftrConnectingStringBottom))
                 {
-                    // Wireless multi
+                    // Wireless multi or mismatch
                     setFighterMainMenu(false);
                 }
                 else
@@ -1346,8 +1353,11 @@ void fighterP2pConCbFn(p2pInfo* p2p, connectionEvt_t evt)
         }
         case CON_ESTABLISHED:
         {
-            // Connection established, show character select screen
-            setFighterMultiplayerCharSelMenu(true);
+            // Connection established, check version
+            if(GOING_FIRST == p2pGetPlayOrder(p2p))
+            {
+                fighterSendVersionToOther();
+            }
             break;
         }
         case CON_LOST:
@@ -1376,7 +1386,27 @@ void fighterP2pMsgRxCbFn(p2pInfo* p2p, const uint8_t* payload, uint8_t len)
         case FIGHTER_WAITING:
         {
             // Check what was received
-            if(payload[0] == CHAR_SEL_MSG)
+            if(payload[0] == VERSION_MSG)
+            {
+                if(0 == memcmp(&payload[1], GIT_SHA1, 7))
+                {
+                    // Connection established, show character select screen
+                    setFighterMultiplayerCharSelMenu(true);
+                }
+                else
+                {
+                    // Version mismatch, show warning
+                    fm->ftrConnectingStringTop = str_version_mismatch;
+                    fm->ftrConnectingStringBottom = str_visit_swadge_com;
+                }
+
+                // Reply with version
+                if(GOING_SECOND == p2pGetPlayOrder(p2p))
+                {
+                    fighterSendVersionToOther();
+                }
+            }
+            else if(payload[0] == CHAR_SEL_MSG)
             {
                 // Receive a character selection, so save it
                 uint8_t charIdx = (GOING_FIRST == fm->p2p.cnc.playOrder) ? 1 : 0;
@@ -1492,6 +1522,18 @@ void fighterCheckGameBegin(void)
                          fm->stage, GOING_FIRST == fm->p2p.cnc.playOrder);
         fm->screen = FIGHTER_GAME;
     }
+}
+
+/**
+ * @brief Send a packet to the other swadge with this's player's version
+ */
+void fighterSendVersionToOther(void)
+{
+    uint8_t payload[8] = {VERSION_MSG};
+    memcpy(&payload[1], GIT_SHA1, 7);
+    // Send button state to the other swawdge
+    p2pSendMsg(&fm->p2p, payload, sizeof(payload), fighterP2pMsgTxCbFn);
+    fm->lastSentMsg = VERSION_MSG;
 }
 
 /**

--- a/main/modes/fighter/mode_fighter.c
+++ b/main/modes/fighter/mode_fighter.c
@@ -2265,7 +2265,7 @@ void checkFighterHitboxCollisions(fighter_t* ftr, fighter_t* otherFtr)
 /**
  * Apply deferred hitstun and knockback after both fighter's hitboxes were
  * checked this frame
- * 
+ *
  * @param ftr The fighter to check
  */
 void checkFigherDeferredHitstun(fighter_t* ftr)
@@ -2350,7 +2350,7 @@ void checkFighterProjectileCollisions(list_t* projectiles)
 
                         // After receiving damage, clear freefall to enable up+b
                         ftr->isInFreefall = false;
-                        
+
                         // Note the fighter was hit for SFX & LEDs
                         ftr->damagedThisFrame = true;
 

--- a/main/modes/fighter/mode_fighter.c
+++ b/main/modes/fighter/mode_fighter.c
@@ -557,9 +557,9 @@ void getHurtbox(fighter_t* ftr, box_t* hurtbox)
 void _setFighterState(fighter_t* ftr, fighterState_t newState, offsetSprite_t* newSprite,
                       int32_t timer, vector_t* knockback, uint32_t line)
 {
-    // if(ftr == &f->fighters[1])
+    // if(ftr == &f->fighters[0])
     // {
-    //     ESP_LOGD("FTR", "%s:%d %d\n", __func__, line, newState);
+    //     ESP_LOGD("FTR", "%s:%d %d", __func__, line, newState);
     // }
 
     // Clean up variables when leaving a state
@@ -664,7 +664,7 @@ void _setFighterRelPos(fighter_t* ftr, platformPos_t relPos, const platform_t* t
 {
     // if(ftr == &f->fighters[0])
     // {
-    //     ESP_LOGD("FTR", "%s:%d %d, %s\n", __func__, line, relPos, isInAir ? "in air" : "on ground");
+    //     ESP_LOGD("FTR", "%s:%d %d, %s", __func__, line, relPos, isInAir ? "in air" : "on ground");
     // }
 
     ftr->relativePos = relPos;
@@ -2032,8 +2032,11 @@ bool updateFighterPosition(fighter_t* ftr, const platform_t* platforms,
                         setFighterRelPos(ftr, platformPos, &platforms[idx], NULL, true);
                     }
 
-                    // Moving downward
-                    if((false == ftr->ledgeJumped) && (ftr->isInFreefall) && (ftr->velocity.y > 0))
+                    // Check if the fighter is hasn't ledge-jumped, is in freefall downwards,
+                    // and is not in the startup state. A ledge jump in FS_STARTUP may get
+                    // overwritten by a boost in FS_ATTACK
+                    if((false == ftr->ledgeJumped) && (ftr->isInFreefall) &&
+                            (ftr->velocity.y > 0) && (ftr->state != FS_STARTUP) )
                     {
                         // Give a bonus 'jump' to get back on the platform
                         ftr->ledgeJumped = true;

--- a/main/modes/fighter/mode_fighter.c
+++ b/main/modes/fighter/mode_fighter.c
@@ -2250,6 +2250,9 @@ void checkFighterHitboxCollisions(fighter_t* ftr, fighter_t* otherFtr)
                         }
                         otherFtr->deferredKnockback.y = ((hbx->knockback.y * knockbackScalar) / 64);
 
+                        otherFtr->deferredKnockback.x = (otherFtr->deferredKnockback.x * otherFtr->weight) / 1024;
+                        otherFtr->deferredKnockback.y = (otherFtr->deferredKnockback.y * otherFtr->weight) / 1024;
+
                         // Apply hitstun, scaled by defendant's percentage
                         otherFtr->deferredHitsun = hbx->hitstun * (1 + (otherFtr->damage / 32));
 
@@ -2372,6 +2375,9 @@ void checkFighterProjectileCollisions(list_t* projectiles)
                             knockback.x = -((proj->knockback.x * knockbackScalar) / 64);
                         }
                         knockback.y = ((proj->knockback.y * knockbackScalar) / 64);
+
+                        knockback.x = (knockback.x * ftr->weight) / 1024;
+                        knockback.y = (knockback.y * ftr->weight) / 1024;
 
                         // Only apply knockback if nonzero (i.e. don't stop fighter)
                         if(knockback.x || knockback.y)

--- a/main/modes/fighter/mode_fighter.c
+++ b/main/modes/fighter/mode_fighter.c
@@ -2228,6 +2228,9 @@ void checkFighterHitboxCollisions(fighter_t* ftr, fighter_t* otherFtr)
                         otherFtr->damage += hbx->damage;
                         ftr->damageGiven += hbx->damage;
 
+                        // After receiving damage, clear freefall to enable up+b
+                        otherFtr->isInFreefall = false;
+
                         // Note the fighter was hit for SFX & LEDs
                         otherFtr->damagedThisFrame = true;
 
@@ -2345,6 +2348,9 @@ void checkFighterProjectileCollisions(list_t* projectiles)
                         ftr->damage += proj->damage;
                         proj->owner->damageGiven += proj->damage;
 
+                        // After receiving damage, clear freefall to enable up+b
+                        ftr->isInFreefall = false;
+                        
                         // Note the fighter was hit for SFX & LEDs
                         ftr->damagedThisFrame = true;
 

--- a/main/modes/fighter/mode_fighter.c
+++ b/main/modes/fighter/mode_fighter.c
@@ -58,7 +58,7 @@ typedef enum
 
 #define BARRIER_COLOR         c435
 #define BOTTOM_PLATFORM_COLOR c111
-#define TOP_PLATFORM_COLOR    c333
+#define TOP_PLATFORM_COLOR    c232
 #define HUD_COLOR             c444
 #define INVINCIBLE_COLOR      c550
 

--- a/main/modes/fighter/mode_fighter.h
+++ b/main/modes/fighter/mode_fighter.h
@@ -250,6 +250,8 @@ typedef struct
     offsetSprite_t* currentSprite;
     uint32_t hitstopTimer;
     uint8_t hitstopShake;
+    vector_t deferredKnockback;
+    int32_t deferredHitsun;
 } fighter_t;
 
 typedef struct

--- a/main/modes/fighter/mode_fighter.h
+++ b/main/modes/fighter/mode_fighter.h
@@ -203,6 +203,8 @@ typedef struct
     uint16_t landingLag;
     /* how floaty a jump is */
     int32_t gravity;
+    /* weight is a scalar for knockback */
+    int32_t weight;
     /* A negative velocity applied when jumping.
      * The more negative, the higher the jump
      */

--- a/main/modes/fighter/mode_fighter.h
+++ b/main/modes/fighter/mode_fighter.h
@@ -230,8 +230,9 @@ typedef struct
     uint8_t stockIconIdx;
     /* Input Tracking */
     int32_t prevBtnState;
-    int32_t btnState;
-    int32_t btnPressesSinceLast;
+    int32_t btnStateBuf[10];
+    int16_t bsBufHead;
+    int16_t bsBufTail;
     /* Current state tracking */
     fighterState_t state;
     bool isAerialAttack;

--- a/main/modes/mode_main_menu.c
+++ b/main/modes/mode_main_menu.c
@@ -83,6 +83,7 @@ typedef struct
     wsg_t usb;
     int32_t autoLightDanceTimer;
     bool debugMode;
+    char gitStr[32];
 } mainMenu_t;
 
 //==============================================================================
@@ -172,6 +173,8 @@ void mainMenuEnterMode(display_t* disp)
     loadWsg("batt3.wsg", &mainMenu->batt[2]);
     loadWsg("batt4.wsg", &mainMenu->batt[3]);
     loadWsg("usb.wsg", &mainMenu->usb);
+
+    sprintf(mainMenu->gitStr, "Git: %s", GIT_SHA1);
 
     // Initialize the menu
     mainMenu->menu = initMeleeMenu(mainMenuTitle, &mainMenu->meleeMenuFont, mainMenuTopLevelCb);
@@ -782,6 +785,7 @@ void mainMenuSetUpSecretMenu(bool resetPos)
     resetMeleeMenu(mainMenu->menu, mainMenuSecret, mainMenuSecretCb);
     addRowToMeleeMenu(mainMenu->menu, modeBee.modeName);
     addRowToMeleeMenu(mainMenu->menu, modeTest.modeName);
+    addRowToMeleeMenu(mainMenu->menu, mainMenu->gitStr);
     addRowToMeleeMenu(mainMenu->menu, mainMenuBack);
     // Set the position
     if(resetPos)


### PR DESCRIPTION
* Fix bug where p1 would have priority if both player's hit/hurtboxes intersect in the same frame
* Clear freefall after getting hit so that the fighter can up+b recover again
* Recolor platforms
* Add `GIT_SHA1` to build and use it to version check when connecting swadges wirelessly
* Allow attacks with 0 hitstun and 0 knockback
* Add weight attribute. Valid range is 1->2047. 1024 is average (what it had been before)
* Fix ledge jump to occur after up+b attack jumps
* Buffer button inputs
    * Fixes short hops when press & release was in one frame
    * Fixes up+b during short hop not fully jumping