### PR TITLE
Paint cursor fixes

### DIFF
--- a/main/modes/paint/paint_brush.c
+++ b/main/modes/paint/paint_brush.c
@@ -10,7 +10,7 @@
 
 void paintDrawSquarePen(paintCanvas_t* canvas, point_t* points, uint8_t numPoints, uint16_t size, paletteColor_t col)
 {
-    plotRectFilledScaled(canvas->disp, points[0].x, points[0].y, points[0].x + (size), points[0].y + (size), col, canvas->x, canvas->y, canvas->xScale, canvas->yScale);
+    plotRectFilledScaled(canvas->disp, points[0].x - (size / 2), points[0].y - (size / 2), points[0].x + ((size + 1) / 2), points[0].y + ((size + 1) / 2), col, canvas->x, canvas->y, canvas->xScale, canvas->yScale);
 }
 
 void paintDrawCirclePen(paintCanvas_t* canvas, point_t* points, uint8_t numPoints, uint16_t size, paletteColor_t col)

--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -105,7 +105,7 @@ brush_t brushes[] =
     { .name = "Filled Circle", .mode = PICK_POINT, .maxPoints = 2, .minSize = 0, .maxSize = 0, .fnDraw = paintDrawFilledCircle, .iconName = "circle_filled" },
     { .name = "Ellipse",    .mode = PICK_POINT, .maxPoints = 2, .minSize = 1, .maxSize = 8, .fnDraw = paintDrawEllipse, .iconName = "ellipse" },
     { .name = "Polygon",    .mode = PICK_POINT_LOOP, .maxPoints = 16, .minSize = 1, .maxSize = 8, .fnDraw = paintDrawPolygon, .iconName = "polygon" },
-    { .name = "Squarewave", .mode = PICK_POINT, .maxPoints = 2, .minSize = 0, .maxSize = 32, .fnDraw = paintDrawSquareWave, .iconName = "squarewave" },
+    { .name = "Squarewave", .mode = PICK_POINT, .maxPoints = 2, .minSize = 0, .maxSize = 0, .fnDraw = paintDrawSquareWave, .iconName = "squarewave" },
     { .name = "Paint Bucket", .mode = PICK_POINT, .maxPoints = 1, .minSize = 0, .maxSize = 0, .fnDraw = paintDrawPaintBucket, .iconName = "paint_bucket" },
 };
 

--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -95,8 +95,8 @@ static paletteColor_t defaultPalette[] =
 
 brush_t brushes[] =
 {
-    { .name = "Square Pen", .mode = HOLD_DRAW,  .maxPoints = 1, .minSize = 1, .maxSize = 32, .fnDraw = paintDrawSquarePen, .iconName = "square_pen" },
-    { .name = "Circle Pen", .mode = HOLD_DRAW,  .maxPoints = 1, .minSize = 1, .maxSize = 32, .fnDraw = paintDrawCirclePen, .iconName = "circle_pen" },
+    { .name = "Square Pen", .mode = HOLD_DRAW,  .maxPoints = 1, .minSize = 1, .maxSize = 16, .fnDraw = paintDrawSquarePen, .iconName = "square_pen" },
+    { .name = "Circle Pen", .mode = HOLD_DRAW,  .maxPoints = 1, .minSize = 1, .maxSize = 16, .fnDraw = paintDrawCirclePen, .iconName = "circle_pen" },
     { .name = "Line",       .mode = PICK_POINT, .maxPoints = 2, .minSize = 1, .maxSize = 8, .fnDraw = paintDrawLine, .iconName = "line" },
     { .name = "Bezier Curve", .mode = PICK_POINT, .maxPoints = 4, .minSize = 1, .maxSize = 8, .fnDraw = paintDrawCurve, .iconName = "curve" },
     { .name = "Rectangle",  .mode = PICK_POINT, .maxPoints = 2, .minSize = 1, .maxSize = 8, .fnDraw = paintDrawRectangle, .iconName = "rect" },

--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -271,6 +271,8 @@ void paintDrawScreenSetup(display_t* disp)
 
     paintState->disp->clearPx();
 
+    paintSetupTool();
+
     // Clear the LEDs
     // Might not be necessary here
     paintUpdateLeds();

--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -466,10 +466,8 @@ void paintDrawScreenMainLoop(int64_t elapsedUs)
                     getArtist()->fgColor = paintState->canvas.palette[0];
                     getArtist()->bgColor = paintState->canvas.palette[1];
 
-                    paintFreeCursorSprite(&paintState->cursorWsg);
-                    paintGenerateCursorSprite(&paintState->cursorWsg, &paintState->canvas);
-                    setCursorSprite(getCursor(), &paintState->canvas, &paintState->cursorWsg);
-                    setCursorOffset(getCursor(), (paintState->canvas.xScale - paintState->cursorWsg.w) / 2, (paintState->canvas.yScale - paintState->cursorWsg.h) / 2);
+                    // Do the tool setup, which will also setup the cursor
+                    paintSetupTool();
 
                     // Put the cursor in the middle of the screen
                     moveCursorAbsolute(getCursor(), &paintState->canvas, paintState->canvas.w / 2, paintState->canvas.h / 2);
@@ -1681,10 +1679,18 @@ void paintSetupTool(void)
     switch (getArtist()->brushDef->mode)
     {
         case HOLD_DRAW:
+        {
+            // Regenerate the cursor if it's not been set yet or if the brush's size is different from the cursor's size
+            if (paintState->cursorWsg.px == NULL || paintState->cursorWsg.w != (paintState->canvas.xScale + 2) || paintState->cursorWsg.h != (paintState->canvas.yScale + 2))
+            {
+                paintFreeCursorSprite(&paintState->cursorWsg);
+                paintGenerateCursorSprite(&paintState->cursorWsg, &paintState->canvas);
+            }
+
             setCursorSprite(getCursor(), &paintState->canvas, &paintState->cursorWsg);
             setCursorOffset(getCursor(), (paintState->canvas.xScale - paintState->cursorWsg.w) / 2, (paintState->canvas.yScale - paintState->cursorWsg.h) / 2);
-
-        break;
+            break;
+        }
 
         case PICK_POINT:
         case PICK_POINT_LOOP:

--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -1689,7 +1689,8 @@ void paintSetupTool(void)
             }
 
             setCursorSprite(getCursor(), &paintState->canvas, &paintState->cursorWsg);
-            setCursorOffset(getCursor(), (getArtist()->brushWidth * paintState->canvas.xScale - paintState->cursorWsg.w) / 2, (getArtist()->brushWidth * paintState->canvas.yScale - paintState->cursorWsg.h) / 2);
+            // Center the cursor, accounting for even and odd cursor sizes
+            setCursorOffset(getCursor(), -(paintState->cursorWsg.w / 2) + getArtist()->brushWidth % 2, -(paintState->cursorWsg.h / 2) + getArtist()->brushWidth % 2);
             break;
         }
 

--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -252,7 +252,8 @@ void paintDrawScreenSetup(display_t* disp)
         getArtist()->bgColor = paintState->canvas.palette[1];
     }
 
-    paintGenerateCursorSprite(&paintState->cursorWsg, &paintState->canvas);
+    // This assumes the first brush is a pen brush, which it always will be unless we rearrange the brush array
+    paintGenerateCursorSprite(&paintState->cursorWsg, &paintState->canvas, firstBrush->minSize);
 
     // Init the cursors for each artist
     // TODO only do one for singleplayer?
@@ -1681,14 +1682,14 @@ void paintSetupTool(void)
         case HOLD_DRAW:
         {
             // Regenerate the cursor if it's not been set yet or if the brush's size is different from the cursor's size
-            if (paintState->cursorWsg.px == NULL || paintState->cursorWsg.w != (paintState->canvas.xScale + 2) || paintState->cursorWsg.h != (paintState->canvas.yScale + 2))
+            if (paintState->cursorWsg.px == NULL || paintState->cursorWsg.w != (getArtist()->brushWidth * paintState->canvas.xScale + 2) || paintState->cursorWsg.h != (getArtist()->brushWidth * paintState->canvas.yScale + 2))
             {
                 paintFreeCursorSprite(&paintState->cursorWsg);
-                paintGenerateCursorSprite(&paintState->cursorWsg, &paintState->canvas);
+                paintGenerateCursorSprite(&paintState->cursorWsg, &paintState->canvas, getArtist()->brushWidth);
             }
 
             setCursorSprite(getCursor(), &paintState->canvas, &paintState->cursorWsg);
-            setCursorOffset(getCursor(), (paintState->canvas.xScale - paintState->cursorWsg.w) / 2, (paintState->canvas.yScale - paintState->cursorWsg.h) / 2);
+            setCursorOffset(getCursor(), (getArtist()->brushWidth * paintState->canvas.xScale - paintState->cursorWsg.w) / 2, (getArtist()->brushWidth * paintState->canvas.yScale - paintState->cursorWsg.h) / 2);
             break;
         }
 
@@ -1749,6 +1750,8 @@ void paintSetBrushWidth(uint8_t width)
     {
         getArtist()->brushWidth = width;
     }
+
+    paintSetupTool();
     paintState->redrawToolbar = true;
 }
 
@@ -1762,6 +1765,8 @@ void paintDecBrushWidth(uint8_t dec)
     {
         getArtist()->brushWidth -= dec;
     }
+
+    paintSetupTool();
     paintState->redrawToolbar = true;
 }
 
@@ -1773,6 +1778,8 @@ void paintIncBrushWidth(uint8_t inc)
     {
         getArtist()->brushWidth = getArtist()->brushDef->maxSize;
     }
+
+    paintSetupTool();
     paintState->redrawToolbar = true;
 }
 

--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -1694,9 +1694,12 @@ void paintSetupTool(void)
 
         case PICK_POINT:
         case PICK_POINT_LOOP:
+        {
             setCursorSprite(getCursor(), &paintState->canvas, &paintState->picksWsg);
-            setCursorOffset(getCursor(), -paintState->picksWsg.w, paintState->canvas.yScale);
-        break;
+            // Place the top-right pixel of the pointer 1px inside the target pixel
+            setCursorOffset(getCursor(), -paintState->picksWsg.w + 1, paintState->canvas.yScale - 1);
+            break;
+        }
     }
     showCursor(getCursor(), &paintState->canvas);
 

--- a/main/modes/paint/paint_ui.c
+++ b/main/modes/paint/paint_ui.c
@@ -408,10 +408,10 @@ void paintClearCanvas(const paintCanvas_t* canvas, paletteColor_t bgColor)
 }
 
 // Generates a cursor sprite that's a box
-void paintGenerateCursorSprite(wsg_t* cursorWsg, const paintCanvas_t* canvas)
+void paintGenerateCursorSprite(wsg_t* cursorWsg, const paintCanvas_t* canvas, uint8_t size)
 {
-    cursorWsg->w = canvas->xScale + 2;
-    cursorWsg->h = canvas->yScale + 2;
+    cursorWsg->w = size * canvas->xScale + 2;
+    cursorWsg->h = size * canvas->yScale + 2;
     cursorWsg->px = malloc(sizeof(paletteColor_t) * cursorWsg->w * cursorWsg->h);
 
     paletteColor_t pxVal;

--- a/main/modes/paint/paint_ui.h
+++ b/main/modes/paint/paint_ui.h
@@ -23,7 +23,7 @@ void paintRenderAll(void);
 
 void paintClearCanvas(const paintCanvas_t* canvas, paletteColor_t bgColor);
 
-void paintGenerateCursorSprite(wsg_t* sprite, const paintCanvas_t* canvas);
+void paintGenerateCursorSprite(wsg_t* sprite, const paintCanvas_t* canvas, uint8_t size);
 void paintFreeCursorSprite(wsg_t* sprite);
 
 void initCursor(paintCursor_t* cursor, paintCanvas_t* canvas, const wsg_t* sprite);


### PR DESCRIPTION
* Fixes #271
* Tweaks positioning of pick-point cursor to make it more obvious which pixel it's pointing to
* Reduces max size of pen brushes to 16 and removes size option for squarewave
* Scales cursor with brush size
* Fixes off-center square pen