### PR TITLE
Fix wrong order of operations when clearing pick points at cursor change

### DIFF
--- a/main/modes/paint/paint_draw.c
+++ b/main/modes/paint/paint_draw.c
@@ -1682,6 +1682,7 @@ void paintSetupTool(void)
     }
 
     hideCursor(getCursor(), &paintState->canvas);
+    paintHidePickPoints();
     switch (getArtist()->brushDef->mode)
     {
         case HOLD_DRAW:
@@ -1708,10 +1709,10 @@ void paintSetupTool(void)
             break;
         }
     }
-    showCursor(getCursor(), &paintState->canvas);
 
     // Undraw and hide any stored temporary pixels
     while (popPxScaled(&getArtist()->pickPoints, paintState->disp, paintState->canvas.xScale, paintState->canvas.yScale));
+    showCursor(getCursor(), &paintState->canvas);
 }
 
 void paintPrevTool(void)


### PR DESCRIPTION
This prevents subpixels of the pick points being left behind if the cursor is over top of them when the brush is changed. Thanks, fuzzer!