### PR TITLE
Restore flyin donut y-invert to original default value

### DIFF
--- a/main/modes/mode_flight.c
+++ b/main/modes/mode_flight.c
@@ -219,7 +219,7 @@ bool getFlightSaveData(flight_t* flightPtr)
             memset( &flightPtr->savedata, 0, sizeof( flightPtr->savedata ) );
 
             // Set defaults here!
-            flightPtr->savedata.flightInvertY = 1;
+            flightPtr->savedata.flightInvertY = 0;
         }
         flightPtr->didFlightsimDataLoad = 1;
     }
@@ -1198,7 +1198,7 @@ static void flightGameUpdate( flight_t * tflight )
         if( bs & 1 ) dyaw += THRUSTER_ACCEL;
         if( bs & 2 ) dyaw -= THRUSTER_ACCEL;
 
-        if( !tflight->savedata.flightInvertY ) dyaw *= -1;
+        if( tflight->savedata.flightInvertY ) dyaw *= -1;
 
         // If flying upside down, invert left/right. (Optional see flip note below)
         if( tflight->hpr[1] >= 990 && tflight->hpr[1] < 2970 ) dpitch *= -1;

--- a/main/modes/mode_flight.h
+++ b/main/modes/mode_flight.h
@@ -15,9 +15,10 @@ extern swadgeMode modeFlight;
 
 typedef struct __attribute__((aligned(4)))
 {
-    //One set for any% one set for 100%
+    // One set for any% one set for 100%
     char displayName[NUM_FLIGHTSIM_TOP_SCORES * 2][FLIGHT_HIGH_SCORE_NAME_LEN];
     uint32_t timeCentiseconds[NUM_FLIGHTSIM_TOP_SCORES * 2];
+    // 0 = D-pad down to pitch up, 1 = D-pad up to pitch up. Opposite of most games' y-invert settings
     uint8_t flightInvertY;
 }
 flightSimSaveData_t;


### PR DESCRIPTION
The way y-invert is used in flyin' donut is opposite from most other games, so I was confused when I was dynamifying y-invert and altering the way it's saved and loaded.

This change preserves saved y-invert settings from 1.0 swadges.