### PR TITLE
Forced length 7 for --short flag for git hash

### DIFF
--- a/emu.mk
+++ b/emu.mk
@@ -114,7 +114,7 @@ CFLAGS_WARNINGS_EXTRA = \
 ################################################################################
 
 # Create a variable with the git hash and branch name
-GIT_HASH  = \"$(shell git rev-parse --short HEAD)\"
+GIT_HASH  = \"$(shell git rev-parse --short=7 HEAD)\"
 
 # Used by the ESP SDK
 DEFINES_LIST = \

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -103,7 +103,7 @@ spiffs_create_partition_image(storage ../spiffs_image FLASH_IN_PROJECT)
 
 
 execute_process(
-    COMMAND git rev-parse --short HEAD
+    COMMAND git rev-parse --short=7 HEAD
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE VERSION_SHA1 )
 


### PR DESCRIPTION
The --short flag for git rev-parse defaults to a value set in git config, it can vary across systems. If set to something greater than 7, a compiler error will be generated because the length of the string used to display the git hash in the secret menu is set to 7. This modifies the calls for git rev-parse --short to force them to return length 7 so that no discrepancies can occur.