### PR TITLE
Make Tiltrads mode name consistent in menu

### DIFF
--- a/main/modes/mode_tiltrads.c
+++ b/main/modes/mode_tiltrads.c
@@ -1589,7 +1589,7 @@ void applyLEDBrightness(uint8_t numLEDs, double brightness);
 // Mode struct hook
 swadgeMode modeTiltrads =
 {
-    .modeName = "Tiltrads",
+    .modeName = "Tiltrads Color",
     .fnEnterMode = ttInit,
     .fnExitMode = ttDeInit,
     .fnMainLoop = ttUpdate,


### PR DESCRIPTION
The name is "Tiltrads Color" in the manual and in the mode itself. @jt-moriarty asked if it would fit, and it does:
![image](https://user-images.githubusercontent.com/666399/209421010-d65e004f-99d1-47de-b01e-aa2dcb6d68ee.png)
