### PR TITLE
Picross tentative mark line width

### DIFF
--- a/main/modes/picross/mode_picross.c
+++ b/main/modes/picross/mode_picross.c
@@ -1124,11 +1124,9 @@ void drawPicrossScene(display_t* d)
                 if(p->tentativeMarks[i][j] == true) {
                     // Following convention of how X marks always use emptySpaceCol instead of hoverSpaceCol 
                     int boxSize = box.x1-box.x0;
-                    int lineWidth;
+                    int lineWidth = (boxSize/5);
                     if (boxSize < 12) {
-                        lineWidth = (boxSize/5) + 1;
-                    } else { 
-                        lineWidth = (boxSize/5);
+                        lineWidth++;
                     }
                     int outerPadding = (boxSize/4);
                     box_t innerBox =

--- a/main/modes/picross/mode_picross.c
+++ b/main/modes/picross/mode_picross.c
@@ -1124,7 +1124,12 @@ void drawPicrossScene(display_t* d)
                 if(p->tentativeMarks[i][j] == true) {
                     // Following convention of how X marks always use emptySpaceCol instead of hoverSpaceCol 
                     int boxSize = box.x1-box.x0;
-                    int lineWidth = (boxSize/5);
+                    int lineWidth;
+                    if (boxSize < 12) {
+                        lineWidth = (boxSize/5) + 1;
+                    } else { 
+                        lineWidth = (boxSize/5);
+                    }
                     int outerPadding = (boxSize/4);
                     box_t innerBox =
                         {


### PR DESCRIPTION
By suggestion, I increased the line width of the tentative mark boxes by 1 pixel inward when the box size is less than 12 pixels.

I think this looks better - Previously, the last puzzle had the tentative marks only 2 pixels thick on the last puzzle, so this makes them much more visible. One possible downside to hardcoding the pixel threshold like this is that someone may have to tweak the conditional if we add any bigger puzzles or change the screen resolution.

5x5, no change:
![image](https://user-images.githubusercontent.com/49847116/210284933-260807c7-8b28-4979-aa67-74127e826b28.png)
10x10, no change:
![image](https://user-images.githubusercontent.com/49847116/210284942-57b65f5a-ac2f-4781-822a-c8047ec84889.png)
Shorter-hint 15x15 with 12-pixel boxes and therefore no change:
![image](https://user-images.githubusercontent.com/49847116/210284951-16804170-6719-4ec8-8d19-481d91bea255.png)
15x15 with longer hints changed to be thicker: 
![image](https://user-images.githubusercontent.com/49847116/210285064-92d8a180-0212-4648-a6b4-526b4350e51f.png)
